### PR TITLE
Terraform script for CloudWatch Provenance Alarm

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -25,7 +25,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-region: us-west-2
-        role-to-assume: arn:aws:iam::445837347542:role/am-pds-dev
+        role-to-assume: ${{ secrets.ROLE_NAME }}
         role-session-name: MySessionName
 
     - name: Setup Terraform
@@ -37,7 +37,7 @@ jobs:
       run: |
         terraform init
         terraform validate -no-color
-        
+
     - name: Terraform Plan
       id: plan
       working-directory: ${{ env.working-directory }}
@@ -53,4 +53,4 @@ jobs:
     - name: Terraform Apply
       id: apply
       working-directory: ${{ env.working-directory }}
-      run: terraform apply
+      run: terraform apply -auto-approve

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -1,0 +1,56 @@
+name: 'Terraform-Plan'
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: 'Terraform'
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ./terraform
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        aws-region: us-west-2
+        role-to-assume: arn:aws:iam::445837347542:role/am-pds-dev
+        role-session-name: MySessionName
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v2
+
+    - name: Terraform Init & Validate
+      id : init
+      working-directory: ${{ env.working-directory }}
+      run: |
+        terraform init
+        terraform validate -no-color
+        
+    - name: Terraform Plan
+      id: plan
+      working-directory: ${{ env.working-directory }}
+      run: terraform plan -input=false -no-color
+      continue-on-error:  true
+    
+    - name: Terraform Plan Status
+      id : plan_status
+      working-directory: ${{ env.working-directory }}
+      if: steps.plan.outcome == 'failure'
+      run: exit 1
+
+    - name: Terraform Apply
+      id: apply
+      working-directory: ${{ env.working-directory }}
+      run: terraform apply

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -25,7 +25,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-region: us-west-2
-        role-to-assume: arn:aws:iam::445837347542:role/am-pds-dev
+        role-to-assume: ${{ secrets.ROLE_NAME }}
         role-session-name: MySessionName
 
     - name: Setup Terraform

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -1,0 +1,51 @@
+name: 'Terraform-Plan'
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: 'Terraform'
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ./terraform
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        aws-region: us-west-2
+        role-to-assume: arn:aws:iam::445837347542:role/am-pds-dev
+        role-session-name: MySessionName
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v2
+
+    - name: Terraform Init & Validate
+      id : init
+      working-directory: ${{ env.working-directory }}
+      run: |
+        terraform init
+        terraform validate -no-color
+
+    - name: Terraform Plan
+      id: plan
+      working-directory: ${{ env.working-directory }}
+      run: terraform plan -input=false -no-color
+      continue-on-error:  true
+    
+    - name: Terraform Plan Status
+      id : plan_status
+      working-directory: ${{ env.working-directory }}
+      if: steps.plan.outcome == 'failure'
+      run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,10 @@ typescript
 !.gitattributes
 !.gitignore
 !.gitkeep
+
+# Local .terraform files and directories
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -17,7 +17,7 @@ export AWS_SESSION_TOKEN=<temp-session-token>
 export AWS_DEFAULT_REGION=us-west-2
 ```
 
-Alternatively, you can also export your profile 
+ Alternatively, you can also export your profile 
 
 ```
 export AWS_PROFILE=<profile_name>
@@ -38,27 +38,27 @@ cd git/registry-sweepers/terraform/
 4. Execute the following TF commands :
 
 ```
-terraform init"
+terraform init
 ```
 
 ```
-terraform validate"
+terraform validate
 ```
 
 ```
-terraform plan -var-file=./tfvars/pub_dev.tfvars"
+terraform plan
 ```
 
 ```
-terraform apply -var-file=./tfvars/pub_dev.tfvars -auto-approve"
+terraform apply
 ```
 
 ```
-terraform destroy"
+terraform destroy
 ```
 
 **Note:**
 
 1. You should only pass the **-auto-approve** flag while running `terraform apply` and `terraform destroy` if you've already reviewed the changes and are sure you want those changes to get applied.
 
-2. Your assumed IAM role may or may not have permissions create resources withing AWS in which case you will get a `AuthorizationError`.
+2. Your assumed IAM role may or may not have permissions to create resources within AWS in which case you will get a `AuthorizationError`.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,64 @@
+# Terraform to Deploy Provenance Monitoring Alarm
+
+The purpose of this cloudwatch metric alarm is to monitor provenance script failures.
+
+## Prerequisites
+- Terraform
+- AWS CLI (optional)
+
+## Steps to Deploy Provenance CloudWatch Alarm using Terraform
+
+1. Open a terminal and set the following environment variables with correct values associated with your AWS account :
+
+```shell
+export AWS_ACCESS_KEY_ID=<access-key-id>
+export AWS_SECRET_ACCESS_KEY=<secret-access-key>
+export AWS_SESSION_TOKEN=<temp-session-token>
+export AWS_DEFAULT_REGION=us-west-2
+```
+
+Alternatively, you can also export your profile 
+
+```
+export AWS_PROFILE=<profile_name>
+```
+
+2. Clone this repo into your local git repo :
+
+```
+git clone https://github.com/NASA-PDS/registry-sweepers.git
+```
+
+3. Change current working directory to your local git working directory :
+
+```
+cd git/registry-sweepers/terraform/
+```
+
+4. Execute the following TF commands :
+
+```
+terraform init"
+```
+
+```
+terraform validate"
+```
+
+```
+terraform plan -var-file=./tfvars/pub_dev.tfvars"
+```
+
+```
+terraform apply -var-file=./tfvars/pub_dev.tfvars -auto-approve"
+```
+
+```
+terraform destroy"
+```
+
+**Note:**
+
+1. You should only pass the **-auto-approve** flag while running `terraform apply` and `terraform destroy` if you've already reviewed the changes and are sure you want those changes to get applied.
+
+2. Your assumed IAM role may or may not have permissions create resources withing AWS in which case you will get a `AuthorizationError`.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -26,13 +26,13 @@ export AWS_PROFILE=<profile_name>
 2. Clone this repo into your local git repo :
 
 ```
-git clone https://github.com/NASA-PDS/registry-sweepers.git
+git clone https://github.com/NASA-PDS/monitoring.git
 ```
 
 3. Change current working directory to your local git working directory :
 
 ```
-cd git/registry-sweepers/terraform/
+cd monitoring/terraform/
 ```
 
 4. Execute the following TF commands :

--- a/terraform/alarm.tf
+++ b/terraform/alarm.tf
@@ -1,0 +1,61 @@
+resource "aws_cloudwatch_metric_alarm" "provenance_alarm" {
+  alarm_name                            = "provenance-script-failure"
+  comparison_operator                   = "GreaterThanOrEqualToThreshold"
+  datapoints_to_alarm                   = 1
+  evaluation_periods                    = 1
+  metric_name                           = "provenance_failures"
+  namespace                             = "pds_en_registry_provenance"
+  period                                = 300
+  statistic                             = "Sum"
+  threshold                             = 1
+  treat_missing_data                    = "ignore"
+  alarm_description                     = "Provenance script failure alarm. Check logs at /ecs/pds-en-provenance-failure-logs"
+  alarm_actions                         = [aws_sns_topic.provenance_sns_topic.arn]
+  ok_actions                            = var.ok_actions
+  insufficient_data_actions             = var.insufficient_data_actions
+  evaluate_low_sample_count_percentiles = "evaluate"
+
+  depends_on = [
+    aws_sns_topic.provenance_sns_topic,
+    aws_sns_topic_subscription.provenance_topic_subscription
+  ]
+
+  tags = {
+    Alfa    = var.node_name_abbr
+    Bravo   = var.venue
+    Charlie = var.component
+  }
+}
+
+resource "aws_cloudwatch_log_group" "provenance_logs" {
+  name              = "/ecs/pds-en-provenance-failure-logs"
+  retention_in_days = 0
+
+  tags = {
+    Alfa    = var.node_name_abbr
+    Bravo   = var.venue
+    Charlie = var.component
+  }
+}
+
+resource "aws_sns_topic" "provenance_sns_topic" {
+  name              = "provenance_failure_test"
+  display_name      = "prov_alarm_test"
+  kms_master_key_id = "alias/pdscloud"
+
+  tags = {
+    Alfa    = var.node_name_abbr
+    Bravo   = var.venue
+    Charlie = var.component
+  }
+}
+
+resource "aws_sns_topic_subscription" "provenance_topic_subscription" {
+  topic_arn = aws_sns_topic.provenance_sns_topic.arn
+  protocol  = "email"
+  endpoint  = "pds-prod-notify@jpl.nasa.gov"
+
+  depends_on = [
+    aws_sns_topic.provenance_sns_topic
+  ]
+}

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "pds-state"
+    key    = "infra/monitoring/en_cloudwatch.tfstate"
+    region = "us-west-2"
+  }
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0.0"
+    }
+  }
+}
+provider "aws" {
+  region = var.aws_region
+  # profile = var.aws_profile
+}

--- a/terraform/pub_dev.tfvars
+++ b/terraform/pub_dev.tfvars
@@ -1,3 +1,0 @@
-alfa = "en"
-beta = "prod"
-charlie = "provenance"

--- a/terraform/pub_dev.tfvars
+++ b/terraform/pub_dev.tfvars
@@ -1,0 +1,3 @@
+alfa = "en"
+beta = "prod"
+charlie = "provenance"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,45 @@
+variable "aws_region" {
+  type        = string
+  default     = "us-west-2"
+  description = "AWS Region"
+}
+
+# variable "aws_shared_credentials_file" {
+#   default = "~/.aws/credentials"
+#   description = "AWS shared credentials file"
+# }
+
+# variable "aws_profile" {
+#   default = "default"
+#   description = "AWS profile"
+#}
+
+variable "node_name_abbr" {
+  type        = string
+  default     = "en"
+  description = "Tag value for Alfa"
+}
+
+variable "venue" {
+  type        = string
+  default     = "prod"
+  description = "Tag value for Beta"
+}
+
+variable "component" {
+  type        = string
+  default     = "provenance"
+  description = "Tag value for Beta"
+}
+
+variable "insufficient_data_actions" {
+  type        = list(any)
+  default     = []
+  description = "The list of actions to execute when this alarm transitions into an INSUFFICIENT_DATA state from any other state."
+}
+
+variable "ok_actions" {
+  type        = list(any)
+  default     = []
+  description = "The list of actions to execute when this alarm transitions into an OK state from any other state."
+}


### PR DESCRIPTION
## 🗒️ Summary
This terraform scripts creates a cloudwatch Provenance alarm to monitor Provenance scripts failures.

## ⚙️ Test Data and/or Report
Currently unable to retrieve AWS credentials to be able to execute code in PDS Cloud. CI/CD will have to be configured at a later stage.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

Refs:
- https://github.com/NASA-PDS/registry-sweepers/issues/9
- https://github.com/NASA-PDS/registry/issues/167


